### PR TITLE
Add shim to support fwup public key resolver

### DIFF
--- a/lib/nerves_hub_device/certificate.ex
+++ b/lib/nerves_hub_device/certificate.ex
@@ -1,6 +1,10 @@
 defmodule NervesHubDevice.Certificate do
-  # Get the fwup public keys from the app environment. Support the
-  # old name of `:public_keys` for now.
+  # Get the fwup public keys from the app environment.
+  # For now, this first requires adding a key to the environment that
+  # the resolver depends on until https://github.com/nerves-hub/nerves_hub_cli/pull/125
+  # is merged and released
+  Application.put_env(:nerves_hub, :org, Application.get_env(:nerves_hub_device, :org))
+
   @public_keys Application.get_env(:nerves_hub_device, :fwup_public_keys, [])
                |> NervesHubCLI.resolve_fwup_public_keys()
 


### PR DESCRIPTION
NervesHubCLI depends on `config :nerves_hub, :org` key to be set. However, this library was renamed to `:nerves_hub_device`, so that isn't there.

Until that is decoupled, we need to set that config value to resolve keys