### PR TITLE
Store status of device

### DIFF
--- a/lib/nerves_hub_device/client/default.ex
+++ b/lib/nerves_hub_device/client/default.ex
@@ -24,8 +24,8 @@ defmodule NervesHubDevice.Client.Default do
     Logger.warn("FWUP WARN: #{message}")
   end
 
-  def handle_fwup_message(_fwup_message) do
-    :ok
+  def handle_fwup_message(fwup_message) do
+    Logger.warn("Unknown FWUP message: #{inspect(fwup_message)}")
   end
 
   @impl NervesHubDevice.Client


### PR DESCRIPTION
Changes how state is stored in `NervesHubDevice.Channel` and adds deductions to what the current status of the device is (idle, updating, update failure, etc). It also adds a `connected?` field to the state to be able to check that the channel is still connected to NervesHub.

This will eventually replace `NervesHubDevice.Connection` and be used for a little more introspection on NervesHub for quickly seeing what might be happening on the device.